### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/UpdateActions.yml
+++ b/.github/workflows/UpdateActions.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.0.0
+      - uses: actions/checkout@v4.1.1
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.GIT_TOKEN}}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4.1.1
           
       - name: Log in to Github
-        uses: docker/login-action@v1.12.0
+        uses: docker/login-action@v3.0.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -19,23 +19,23 @@ jobs:
       
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5.0.0
         with:
           images: |
            ghcr.io/${{ github.repository }}
           
       
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@master
+        uses: docker/setup-qemu-action@v3.0.0
         with:
           platforms: linux/amd64, linux/arm64
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@master
+        uses: docker/setup-buildx-action@v3.0.0
 
       - name: Build and push Docker image AMD64
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5.0.0
         with:
           builder: ${{ steps.buildx.outputs.name }}
           push: true


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[docker/login-action](https://github.com/docker/login-action)** published a new release **[v3.0.0](https://github.com/docker/login-action/releases/tag/v3.0.0)** on 2023-09-12T07:51:46Z
* **[docker/build-push-action](https://github.com/docker/build-push-action)** published a new release **[v5.0.0](https://github.com/docker/build-push-action/releases/tag/v5.0.0)** on 2023-09-12T07:46:14Z
* **[docker/metadata-action](https://github.com/docker/metadata-action)** published a new release **[v5.0.0](https://github.com/docker/metadata-action/releases/tag/v5.0.0)** on 2023-09-12T07:55:31Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.1](https://github.com/actions/checkout/releases/tag/v4.1.1)** on 2023-10-17T15:53:17Z
* **[docker/setup-buildx-action](https://github.com/docker/setup-buildx-action)** published a new release **[v3.0.0](https://github.com/docker/setup-buildx-action/releases/tag/v3.0.0)** on 2023-09-12T08:03:47Z
* **[docker/setup-qemu-action](https://github.com/docker/setup-qemu-action)** published a new release **[v3.0.0](https://github.com/docker/setup-qemu-action/releases/tag/v3.0.0)** on 2023-09-12T08:05:57Z
